### PR TITLE
Explain use of Duct in shebangs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,21 @@ filename:
 $ duct update sinatra my_script.rb
 ```
 
-Remember that updating the bundle will update the `Gemfile.lock` section in your script, so remember to save those
-changes.
+### Using Duct in shebangs
+
+Under Unix-like operating systems, you can instruct the program loader to use Duct to run your script. Just put the following [shebang](http://en.wikipedia.org/wiki/Shebang_(Unix)) in the first line of your script:
+
+```ruby
+#!/usr/bin/env duct # ruby
+```
+and add execute permissions to your script:
+
+```zsh
+chmod +x my_script
+```
+
+This gives you the ability to treat your script as an executable that, once in your $PATH, to execute it directly.
+
 
 ### Using the script data
 


### PR DESCRIPTION
I love to use Duct to create small ruby+bundler utilities and use them directly from the command line. To make it easier and skip mentioning duct everytime I've been using it on shebangs.

Initially I ran into problems because ruby interpreter needs to find the "ruby" string in the shebang (http://devoh.com/blog/2012/11/local-environment-variables), hence the "# ruby" part in the shebang. I thought that maybe other people was being bitten by this and would be nice to document it.
